### PR TITLE
Updated typo in README for plugin destination path environent variable and makefile recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This is to provide a backend support for `geth` JSON RPC servers by implementing
 
 - `TLSConfigurationSource` to provide TLS configuration for HTTP and WS RPC servers
 - `AuthenticationManager` to enable RPC servers being OAuth2-compliant resource servers
-that support both JSON Web Token ([JWT](https://tools.ietf.org/html/rfc7519)) and opaque access token format
+  that support both JSON Web Token ([JWT](https://tools.ietf.org/html/rfc7519)) and opaque access token format
 
 ## Prerequisites
 
-* Go 1.13.x
+- Go 1.13.x
 
 ## Quick Start
 
 ```bash
 $ make
-$ PLUGIN_DIST_PATH=<path to store plugin distribution zip file> make dist
+$ PLUGIN_DEST_PATH=<path to store plugin distribution zip file> make dist-local
 ```
 
 ## Configuration
@@ -25,7 +25,7 @@ Refer to the official documentation [here](http://docs.goquorum.com/en/latest/Pl
 
 Access token is validated by one of the following methods when configured:
 
-- [JSON Web Signature](https://tools.ietf.org/html/rfc7515): The JSON Web Key Set ([JWKS](https://tools.ietf.org/html/rfc7517)) is a set of keys which contains the public keys used to verify 
-the JSON Web Token (JWT) issued by the authorization server. JWKS is retrieved via a preconfigured endpoint.
-- [OAuth2 Token Introspection](https://tools.ietf.org/html/rfc7662): support HTTP Basic Authentication and Form Authentication 
-to access the protected introspection endpoint. Other authentication methods may be supported in the future.
+- [JSON Web Signature](https://tools.ietf.org/html/rfc7515): The JSON Web Key Set ([JWKS](https://tools.ietf.org/html/rfc7517)) is a set of keys which contains the public keys used to verify
+  the JSON Web Token (JWT) issued by the authorization server. JWKS is retrieved via a preconfigured endpoint.
+- [OAuth2 Token Introspection](https://tools.ietf.org/html/rfc7662): support HTTP Basic Authentication and Form Authentication
+  to access the protected introspection endpoint. Other authentication methods may be supported in the future.


### PR DESCRIPTION
This PR is to fix 2 minor typos in the docs.